### PR TITLE
Adding lifecycle policy for s3 data buckets

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -7,8 +7,8 @@
 locals {
   instance_alias         = "${ var.instance_name == "" ? "apiary" : format("apiary-%s",var.instance_name) }"
   enable_route53_records = "${ var.apiary_domain_name == "" ? "0" : "1" }"
-  apiary_managed_schemas = "${ split(",",replace(join(",",var.apiary_managed_schemas),"_","-")) }"
-  apiary_data_buckets    = "${ formatlist("%s-%s-%s-%s",local.instance_alias,data.aws_caller_identity.current.account_id,var.aws_region,local.apiary_managed_schemas) }"
+  apiary_managed_schema_name =  ["${data.template_file.schema_names.*.rendered}"]
+  apiary_data_buckets    = "${ formatlist("%s-%s-%s-%s",local.instance_alias,data.aws_caller_identity.current.account_id,var.aws_region,local.apiary_managed_schema_name) }"
   gluedb_prefix          = "${ var.instance_name == "" ? "" : "${var.instance_name}_" }"
 }
 
@@ -22,4 +22,9 @@ data "aws_route53_zone" "apiary_zone" {
   count  = "${local.enable_route53_records}"
   name   = "${var.apiary_domain_name}"
   vpc_id = "${var.vpc_id}"
+}
+
+data "template_file" "schema_names" {
+  count    = "${length(var.apiary_managed_schemas)}"
+  template = "${lookup(var.apiary_managed_schemas[count.index], "schema_name")}"
 }

--- a/s3.tf
+++ b/s3.tf
@@ -13,12 +13,12 @@ data "template_file" "bucket_policy" {
 
   vars {
     #if apiary_shared_schemas is empty or contains current schema, allow customer accounts to access this bucket.
-    customer_principal = "${ length(var.apiary_shared_schemas) == 0 || contains(var.apiary_shared_schemas, element(concat(var.apiary_managed_schemas,list("")),count.index)) ?
+    customer_principal = "${ length(var.apiary_shared_schemas) == 0 || contains(local.apiary_managed_schema_name, element(concat(local.apiary_managed_schema_name,list("")),count.index)) ?
                              join("\",\"", formatlist("arn:aws:iam::%s:root",var.apiary_customer_accounts)) :
                              "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }"
 
     bucket_name       = "${local.apiary_data_buckets[count.index]}"
-    producer_iamroles = "${replace(lookup(var.apiary_producer_iamroles,element(concat(var.apiary_managed_schemas,list("")),count.index),"arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"),",","\",\"")}"
+    producer_iamroles = "${replace(lookup(var.apiary_producer_iamroles,element(concat(local.apiary_managed_schema_name,list("")),count.index),"arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"),",","\",\"")}"
   }
 }
 
@@ -36,6 +36,15 @@ resource "aws_s3_bucket" "apiary_data_bucket" {
   logging {
     target_bucket = "${var.apiary_log_bucket}"
     target_prefix = "${var.apiary_log_prefix}${local.apiary_data_buckets[count.index]}/"
+  }
+
+  lifecycle_rule {
+    id = "cost_optimization"
+    enabled = true
+    transition {
+      days          = "${lookup(var.apiary_managed_schemas[count.index], "s3_lifecycle_policy_transition_period", var.s3_lifecycle_policy_transition_period)}"
+      storage_class = "${lookup(var.apiary_managed_schemas[count.index], "s3_storage_class", var.s3_storage_class)}"
+    }
   }
 }
 

--- a/sns.tf
+++ b/sns.tf
@@ -29,7 +29,7 @@ POLICY
 
 resource "aws_sns_topic" "apiary_data_events" {
   count = "${ var.enable_data_events == "" ? 0 : length(var.apiary_managed_schemas) }"
-  name  = "${local.instance_alias}-${local.apiary_managed_schemas[count.index]}-data-events"
+  name  = "${local.instance_alias}-${local.apiary_managed_schema_name[count.index]}-data-events"
 
   policy = <<POLICY
 {
@@ -38,7 +38,7 @@ resource "aws_sns_topic" "apiary_data_events" {
         "Effect": "Allow",
         "Principal": {"AWS":"*"},
         "Action": "SNS:Publish",
-        "Resource": "arn:aws:sns:*:*:${local.instance_alias}-${local.apiary_managed_schemas[count.index]}-data-events",
+        "Resource": "arn:aws:sns:*:*:${local.instance_alias}-${local.apiary_managed_schema_name[count.index]}-data-events",
         "Condition":{
             "ArnLike":{"aws:SourceArn":"${aws_s3_bucket.apiary_data_bucket.*.arn[count.index]}"}
         }

--- a/templates.tf
+++ b/templates.tf
@@ -20,7 +20,7 @@ data "template_file" "hms_readwrite" {
     hive_metastore_log_level   = "${var.hms_log_level}"
     nofile_ulimit              = "${var.hms_nofile_ulimit}"
     enable_metrics             = "${var.enable_hive_metastore_metrics}"
-    managed_schemas            = "${join(",",var.apiary_managed_schemas)}"
+    managed_schemas            = "${join(",",local.apiary_managed_schema_name)}"
     instance_name              = "${local.instance_alias}"
     sns_arn                    = "${ var.enable_metadata_events == "" ? "" : join("",aws_sns_topic.apiary_metadata_events.*.arn) }"
     table_param_filter         = "${ var.enable_metadata_events == "" ? "" : var.table_param_filter }"

--- a/variables.tf
+++ b/variables.tf
@@ -332,3 +332,14 @@ variable "docker_registry_auth_secret_name" {
   type        = "string"
   default     = ""
 }
+
+variable "s3_storage_class" {
+  description = "S3 storage class after transition using lifecycle policy"
+  default     = "INTELLIGENT_TIERING"
+}
+
+variable "s3_lifecycle_policy_transition_period" {
+  description = "S3 Lifecycle Policy number of days for Transition rule"
+  default     = "30"
+}
+


### PR DESCRIPTION

1. This feature will enable users to configure the storage classes for their s3 buckets by setting it up in a lifecycle policy. By default less frequently accessed data objects will be moved to 'INTELLIGENT_TIERING' storage class after 30 days.
2. Users can also configure the no of days for this transition.